### PR TITLE
add camera switch for compute module

### DIFF
--- a/host_applications/linux/apps/raspicam/README_RaspiMJPEG.md
+++ b/host_applications/linux/apps/raspicam/README_RaspiMJPEG.md
@@ -68,3 +68,4 @@ ru 0  halt RaspiMJPEG and release camera
 ru 1  restart mjpeg-stream
 md 1  start motion detection
 md 0  stop motion detection
+cm 1  select second camera (Raspberry Pi compute module only!)

--- a/host_applications/linux/apps/raspicam/RaspiMCam.c
+++ b/host_applications/linux/apps/raspicam/RaspiMCam.c
@@ -853,6 +853,13 @@ void start_all (int load_conf) {
    //
    status = mmal_component_create(MMAL_COMPONENT_DEFAULT_CAMERA, &camera);
    if(status != MMAL_SUCCESS) error("Could not create camera", 1);
+   MMAL_PARAMETER_INT32_T cam_num = {{MMAL_PARAMETER_CAMERA_NUM, sizeof(cam_num)}, cfg_val[c_camera_num]};
+   status = mmal_port_parameter_set(camera->control, &cam_num.hdr);
+   if(status != MMAL_SUCCESS) error("Could not select camera", 1);
+   if(!camera->output_num) {
+      status = MMAL_ENOSYS;
+      error("Camera doesn't have output ports", 1);
+   }
    status = mmal_port_enable(camera->control, camera_control_callback);
    if(status != MMAL_SUCCESS) error("Could not enable camera control port", 1);
 

--- a/host_applications/linux/apps/raspicam/RaspiMCmds.c
+++ b/host_applications/linux/apps/raspicam/RaspiMCmds.c
@@ -44,8 +44,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "RaspiMJPEG.h"
 
 void process_cmd(char *readbuf, int length) {
-   typedef enum pipe_cmd_type{ca,im,tl,px,bo,tv,an,as,at,ac,ab,sh,co,br,sa,is,vs,rl,ec,em,wb,mm,ie,ce,ro,fl,ri,ss,qu,pv,bi,ru,md,sc,rs,bu,mn,mt,mi,mb,me,mx,mf,vm,vp,wd,sy} pipe_cmd_type;
-   char pipe_cmds[] = "ca,im,tl,px,bo,tv,an,as,at,ac,ab,sh,co,br,sa,is,vs,rl,ec,em,wb,mm,ie,ce,ro,fl,ri,ss,qu,pv,bi,ru,md,sc,rs,bu,mn,mt,mi,mb,me,mx,mf,vm,vp,wd,sy";
+   typedef enum pipe_cmd_type{ca,im,tl,px,bo,tv,an,as,at,ac,ab,sh,co,br,sa,is,vs,rl,ec,em,wb,mm,ie,ce,ro,fl,ri,ss,qu,pv,bi,ru,md,sc,rs,bu,mn,mt,mi,mb,me,mx,mf,vm,vp,wd,sy,cn} pipe_cmd_type;
+   char pipe_cmds[] = "ca,im,tl,px,bo,tv,an,as,at,ac,ab,sh,co,br,sa,is,vs,rl,ec,em,wb,mm,ie,ce,ro,fl,ri,ss,qu,pv,bi,ru,md,sc,rs,bu,mn,mt,mi,mb,me,mx,mf,vm,vp,wd,sy,cn";
    pipe_cmd_type pipe_cmd;
    int parcount;
    char pars[128][10];
@@ -316,6 +316,11 @@ void process_cmd(char *readbuf, int length) {
          break;
       case sy:
          exec_macro(parstring, NULL);
+         break;
+      case cn:
+         stop_all();
+         addUserValue(c_camera_num, pars[0]);
+         start_all(0);
          break;
       default:
          printLog("Unrecognised pipe command\n");

--- a/host_applications/linux/apps/raspicam/RaspiMJPEG.c
+++ b/host_applications/linux/apps/raspicam/RaspiMJPEG.c
@@ -89,6 +89,7 @@ char *cfg_key[] ={
    "motion_noise","motion_threshold","motion_image","motion_startframes","motion_stopframes","motion_pipe",
    "user_config","log_file","watchdog_interval","watchdog_errors","h264_buffers",
    "end_img", "end_vid", "end_box",
+   "camera_num",
 };
 
 

--- a/host_applications/linux/apps/raspicam/RaspiMJPEG.h
+++ b/host_applications/linux/apps/raspicam/RaspiMJPEG.h
@@ -78,7 +78,7 @@ extern char *box_files[MAX_BOX_FILES];
 extern int box_head;
 extern int box_tail;
 //hold config file data for both dflt and user config files and u long versions
-#define KEY_COUNT 80
+#define KEY_COUNT 81
 extern char *cfg_strd[KEY_COUNT + 1];
 extern char *cfg_stru[KEY_COUNT + 1];
 extern long int cfg_val[KEY_COUNT + 1];
@@ -113,7 +113,8 @@ typedef enum cfgkey_type
    c_thumb_gen,c_autostart,c_motion_detection,c_motion_file,c_vector_preview,c_vector_mode,c_motion_external,
    c_motion_noise,c_motion_threshold,c_motion_image,c_motion_startframes,c_motion_stopframes,c_motion_pipe,
    c_user_config,c_log_file,c_watchdog_interval,c_watchdog_errors, c_h264_buffers,
-   c_end_img, c_end_vid, c_end_box
+   c_end_img, c_end_vid, c_end_box,
+   c_camera_num,
    } cfgkey_type; 
 
 time_t currTime;


### PR DESCRIPTION
Raspberry PI Compute module IO Board have possibility to connect two cameras, modern versions of raspivid and raspistill supports camera selection via parameter -cs. This patch adds possibility to raspimjpeg
