### PR TITLE
HDMI Preview: new feature

### DIFF
--- a/host_applications/linux/apps/raspicam/README_RaspiMJPEG.md
+++ b/host_applications/linux/apps/raspicam/README_RaspiMJPEG.md
@@ -69,3 +69,5 @@ ru 1  restart mjpeg-stream
 md 1  start motion detection
 md 0  stop motion detection
 cm 1  select second camera (Raspberry Pi compute module only!)
+dy 0  disable HDMI preview of the camera stream
+dy 1  enable full-screen HDMI preview of the camera stream

--- a/host_applications/linux/apps/raspicam/RaspiMCmds.c
+++ b/host_applications/linux/apps/raspicam/RaspiMCmds.c
@@ -43,9 +43,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //#define MOTION_INTERNAL
 #include "RaspiMJPEG.h"
 
+
 void process_cmd(char *readbuf, int length) {
-   typedef enum pipe_cmd_type{ca,im,tl,px,bo,tv,vi,an,as,at,ac,ab,sh,co,br,sa,is,vs,rl,ec,em,wb,ag,mm,ie,ce,ro,fl,ri,ss,qu,pv,bi,ru,md,sc,rs,bu,mn,mt,mi,ms,mb,me,mc,mx,mf,mz,vm,vp,wd,sy,um,cn,st,ls,qp} pipe_cmd_type;
-   char pipe_cmds[] = "ca,im,tl,px,bo,tv,vi,an,as,at,ac,ab,sh,co,br,sa,is,vs,rl,ec,em,wb,ag,mm,ie,ce,ro,fl,ri,ss,qu,pv,bi,ru,md,sc,rs,bu,mn,mt,mi,ms,mb,me,mc,mx,mf,mz,vm,vp,wd,sy,um,cn,st,ls,qp";
+   typedef enum pipe_cmd_type{ca,im,tl,px,bo,tv,vi,an,as,at,ac,ab,sh,co,br,sa,is,vs,rl,ec,em,wb,ag,mm,ie,ce,ro,fl,ri,ss,qu,pv,bi,ru,md,sc,rs,bu,mn,mt,mi,ms,mb,me,mc,mx,mf,mz,vm,vp,wd,sy,um,cn,st,ls,qp,hp} pipe_cmd_type;
+   char pipe_cmds[] = "ca,im,tl,px,bo,tv,vi,an,as,at,ac,ab,sh,co,br,sa,is,vs,rl,ec,em,wb,ag,mm,ie,ce,ro,fl,ri,ss,qu,pv,bi,ru,md,sc,rs,bu,mn,mt,mi,ms,mb,me,mc,mx,mf,mz,vm,vp,wd,sy,um,cn,st,ls,qp,hp";
    pipe_cmd_type pipe_cmd;
    int parcount;
    char pars[128][10];
@@ -371,6 +372,11 @@ void process_cmd(char *readbuf, int length) {
          break;
       case ls:
          key = c_log_size;
+         break;
+      case hp:
+         key = c_hdmi_preview;
+         printLog("Setting HDMI Preview to %s\n", par0 ? "ON" : "OFF");
+         cam_set_preview(par0);
          break;
       default:
          printLog("Unrecognised pipe command\n");

--- a/host_applications/linux/apps/raspicam/RaspiMJPEG.c
+++ b/host_applications/linux/apps/raspicam/RaspiMJPEG.c
@@ -57,6 +57,9 @@ FILE *jpegoutput_file = NULL, *jpegoutput2_file = NULL, *h264output_file = NULL,
 MMAL_POOL_T *pool_jpegencoder = 0, *pool_jpegencoder_in = 0, *pool_jpegencoder2 = 0, *pool_h264encoder = 0;
 char *cb_buff = NULL;
 
+MMAL_COMPONENT_T *preview = 0, *splitter2 = 0 ;
+MMAL_CONNECTION_T *con_cam_preview = 0, *con_spli_preview = 0 ;
+
 char readbuf[FIFO_MAX][2 * MAX_COMMAND_LEN];
 int fd[FIFO_MAX], readi[FIFO_MAX];
 
@@ -99,7 +102,8 @@ char *cfg_key[] ={
    "motion_noise","motion_threshold","motion_image","motion_initframes","motion_startframes","motion_stopframes","motion_pipe","motion_clip","motion_logfile",
    "user_config","log_file","log_size","watchdog_interval","watchdog_errors","h264_buffer_size","h264_buffers","callback_timeout",
    "error_soft", "error_hard", "start_img", "end_img", "start_vid", "end_vid", "end_box", "do_cmd","motion_event","startstop",
-   "camera_num","stat_pass","user_annotate","count_format","minimise_frag","initial_quant","encode_qp","mmal_logfile","stop_pause"
+   "camera_num","stat_pass","user_annotate","count_format","minimise_frag","initial_quant","encode_qp","mmal_logfile","stop_pause",
+   "hdmi_preview"
 };
 
 
@@ -123,7 +127,6 @@ int getKey(char *key) {
 }
 
 void addValue(int keyI, char *value, int both){
-   
    free(cfg_stru[keyI]);
    cfg_stru[keyI] = 0;
    if (both) {free(cfg_strd[keyI]);cfg_strd[keyI] = 0;}
@@ -154,6 +157,7 @@ void addValue(int keyI, char *value, int both){
          case c_MP4Box:
             if(strcmp(value, "background") == 0)
                val = 2;
+	    break;
       }
       cfg_val[keyI] = val;
    }

--- a/host_applications/linux/apps/raspicam/RaspiMJPEG.h
+++ b/host_applications/linux/apps/raspicam/RaspiMJPEG.h
@@ -58,8 +58,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define IFRAME_BUFSIZE (128*1024)
 #define STD_INTRAPERIOD 60
 extern MMAL_STATUS_T status;
-extern MMAL_COMPONENT_T *camera, *jpegencoder, *jpegencoder2, *h264encoder, *resizer, *null_sink, *splitter;
-extern MMAL_CONNECTION_T *con_cam_pre, *con_spli_res, *con_spli_h264, *con_res_jpeg, *con_cam_h264, *con_cam_jpeg;
+extern MMAL_COMPONENT_T *camera, *jpegencoder, *jpegencoder2, *h264encoder, *resizer, *null_sink, *splitter, *preview;
+extern MMAL_CONNECTION_T *con_cam_pre, *con_spli_res, *con_spli_h264, *con_res_jpeg, *con_cam_h264, *con_cam_jpeg, *con_cam_preview;
 extern FILE *jpegoutput_file, *jpegoutput2_file, *h264output_file, *status_file, *vector_file;
 extern MMAL_POOL_T *pool_jpegencoder, *pool_jpegencoder_in, *pool_jpegencoder2, *pool_h264encoder;
 extern char *cb_buff;
@@ -85,7 +85,7 @@ extern char *box_files[MAX_BOX_FILES];
 extern int box_head;
 extern int box_tail;
 //hold config file data for both dflt and user config files and u long versions
-#define KEY_COUNT 109
+#define KEY_COUNT 110
 extern char *cfg_strd[KEY_COUNT + 1];
 extern char *cfg_stru[KEY_COUNT + 1];
 extern long int cfg_val[KEY_COUNT + 1];
@@ -125,6 +125,7 @@ typedef enum cfgkey_type
    c_user_config,c_log_file,c_log_size,c_watchdog_interval,c_watchdog_errors, c_h264_buffer_size, c_h264_buffers,c_callback_timeout,
    c_error_soft, c_error_hard, c_start_img, c_end_img, c_start_vid, c_end_vid, c_end_box, c_do_cmd,c_motion_event,c_startstop,
    c_camera_num,c_stat_pass,c_user_annotate,c_count_format,c_minimise_frag,c_initial_quant,c_encode_qp,c_mmal_logfile,c_stop_pause,
+   c_hdmi_preview
    } cfgkey_type; 
 
 extern struct timespec currTime;
@@ -174,6 +175,7 @@ void cam_set(int key);
 void h264_enable_output ();
 void start_all (int load_conf);
 void stop_all (void);
+void cam_set_preview (int enable);
 
 //Cmds
 void process_cmd(char *readbuf, int length);


### PR DESCRIPTION
Add ability to show the camera stream on the HDMI output port.
This can be turned on and off from the configuration file with:

    hdmi_preview 1
    hdmi_preview 0

And using a pipe command:

    echo "hp 1" > /var/www/html/media/FIFO
    echo "hp 0" > /var/www/html/media/FIFO

Currently the preview is always full screen. Future improvements can
add more options (similar to raspivid's '--preview x,y,w,h' '--opacity').